### PR TITLE
Fix: Update link color in light mode for better visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 
       /* Link Styling */
       a {
-        color: #444;
+        color: #007bff;
         text-decoration: none;
       }
 


### PR DESCRIPTION
The previous link color (#444) in light mode was too similar to the body text color (#333), making links difficult to distinguish.

This change updates the default link color to #007bff (a standard blue) to ensure links are clearly identifiable against the light background without affecting the link styling in dark mode.