### PR TITLE
feat: add link to new publication on language models

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>kharms</title>
     <link rel="icon" type="image/png" href="/assets/road.png" />
     <meta name="description" content="A bit about me (@kseth), Karthik, aggregated under Daniil Kharm’s name.">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>kharms</title>
     <link rel="icon" type="image/png" href="/assets/road.png" />
     <meta name="description" content="A bit about me (@kseth), Karthik.">
@@ -32,6 +33,11 @@
       </p>
     <hr>
     <h2>academic</h2>
+    <p>
+      <a href="https://arxiv.org/abs/2602.22271" rel="noopener noreferrer" target="_blank">
+        Language model(s): A rigorous probabilistic foundation for causal self-attention, sequence modeling, and stability margins
+      </a>
+    </p>
     <p>
       <a href="/publications/BarbuSethuramanLevySyntheticLikelihoodSER2014.pdf" rel="noopener noreferrer" target="_blank">
         Synthetic Likelihood(s): Inferring model parameters with Monte Carlo simulations and summary statistics


### PR DESCRIPTION
This pull request adds the user's latest arXiv publication to the "academic" section in `index.html`.

Changes include:
- A new paragraph under `<h2>academic</h2>` with a link to `https://arxiv.org/abs/2602.22271`.
- The link title is formatted as: `Language model(s): A rigorous probabilistic foundation for causal self-attention, sequence modeling, and stability margins`.
- A `<meta charset="utf-8">` tag was added to `<head>` to fix broken character encoding on the page (e.g. "I'm" appearing as "Iâ€™m").

---
*PR created automatically by Jules for task [1292362914209453964](https://jules.google.com/task/1292362914209453964) started by @kseth*